### PR TITLE
Handle ✅ reaction to resume automation

### DIFF
--- a/app/routes/webhook_routes.py
+++ b/app/routes/webhook_routes.py
@@ -237,6 +237,18 @@ async def handle_webhook(request: Request):
     logger.info(f"Webhook recebido: {data}")
 
     try:
+        # Rota 0a: Reação de humano para retomar automação
+        if data.get('type') == 'ReactionCallback':
+            phone_raw = data.get('phone')
+            if data.get('fromMe') and data.get('reaction', {}).get('emoji') == '✅' and phone_raw:
+                phone = re.sub(r'\D', '', str(phone_raw))
+                logger.info(f"✅ Reação de humano detectada para {phone}. Desativando hibernação.")
+                await CacheService.deactivate_hibernation(phone)
+                return JSONResponse({"status": "hibernation_deactivated_by_reaction"})
+
+            logger.info("Reação recebida não corresponde aos critérios para retomar automação.")
+            return JSONResponse({"status": "reaction_ignored"})
+
         # Rota 0: PRIORIDADE MÁXIMA - Mensagem enviada por um humano da equipe
         if data.get('fromMe', False) and not data.get('isStatusReply', False):
             phone = data.get('phone')


### PR DESCRIPTION
## Summary
- Resume conversation when agent reacts with ✅ by deactivating hibernation
- Ignore and log other reactions to avoid re-triggering hibernation

## Testing
- `pytest` *(fails: NOTION_API_KEY: Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]; NOTION_DATABASE_ID: Input should be a valid string [type=string_type, input_value=None, input_type=NoneType])*

------
https://chatgpt.com/codex/tasks/task_e_689a134993e88330bd76cc69d31c5a93