### PR TITLE
Handle ✅ reaction to resume automation

### DIFF
--- a/app/routes/webhook_routes.py
+++ b/app/routes/webhook_routes.py
@@ -238,9 +238,11 @@ async def handle_webhook(request: Request):
 
     try:
         # Rota 0a: Reação de humano para retomar automação
-        if data.get('reaction') is not None:
+        reaction = data.get('reaction')
+        if reaction:
             phone_raw = data.get('phone')
-            if data.get('fromMe') and data.get('reaction', {}).get('value') == '✅' and phone_raw:
+            emoji = reaction.get('value')
+            if data.get('fromMe') and emoji == '✅' and phone_raw:
                 phone = re.sub(r'\D', '', str(phone_raw))
                 logger.info(f"✅ Reação de humano detectada para {phone}. Desativando hibernação.")
                 await CacheService.deactivate_hibernation(phone)


### PR DESCRIPTION
## Summary
- Resume conversation when agent reacts with ✅ by deactivating hibernation
- Ignore other reaction events so human messages aren't misclassified

## Testing
- `pytest` *(fails: NOTION_API_KEY: Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]; NOTION_DATABASE_ID: Input should be a valid string [type=string_type, input_value=None, input_type=NoneType])*

------
https://chatgpt.com/codex/tasks/task_e_689a134993e88330bd76cc69d31c5a93